### PR TITLE
Remove `change_kernel` method

### DIFF
--- a/lib/onlyoffice_digitalocean_wrapper/digitalocean_wrapper.rb
+++ b/lib/onlyoffice_digitalocean_wrapper/digitalocean_wrapper.rb
@@ -111,14 +111,6 @@ module OnlyofficeDigitaloceanWrapper
       kernels
     end
 
-    def change_kernel(droplet_name, kernel_name)
-      droplet_id = get_droplet_id_by_name(droplet_name)
-      all_kernels = kernels_of_droplet(droplet_name)
-      needed_kernel_id = all_kernels.find { |cur_kernel| cur_kernel.name == kernel_name }.id
-      client.droplet_actions.change_kernel(droplet_id: droplet_id, kernel: needed_kernel_id)
-      wait_until_droplet_have_status(droplet_name)
-    end
-
     def restore_image_by_name(image_name = 'nct-at-stable', droplet_name = image_name, region = 'nyc2', size = '2gb', tags: nil)
       image_id = get_image_id_by_name(image_name)
       droplet = DropletKit::Droplet.new(name: droplet_name,

--- a/spec/onlyoffice_digitalocean_wrapper_spec.rb
+++ b/spec/onlyoffice_digitalocean_wrapper_spec.rb
@@ -83,13 +83,6 @@ describe OnlyofficeDigitaloceanWrapper::DigitalOceanWrapper, retry: 1, use_priva
       digital_ocean.wait_until_droplet_have_status('wrapper-test')
     end
 
-    it 'change_kernel' do
-      pending('Kernel changing is not working in current images. It is obsolute')
-      expect(digital_ocean.current_kernel('wrapper-test')).not_to eq('Ubuntu 14.04 x64 vmlinuz-3.13.0-52-generic')
-      digital_ocean.change_kernel('wrapper-test', 'Ubuntu 14.04 x64 vmlinuz-3.13.0-52-generic')
-      expect(digital_ocean.current_kernel('wrapper-test')).to eq('Ubuntu 14.04 x64 vmlinuz-3.13.0-52-generic')
-    end
-
     it 'power_off_droplet' do
       digital_ocean.power_off_droplet('wrapper-test')
       expect(digital_ocean.get_droplet_status_by_name('wrapper-test')).to eq('off')


### PR DESCRIPTION
It's not actual any more - all kernel management
in all newest OS are managed by os itself, not DO API.