### PR TITLE
Release v0.4.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,12 @@
 
 # unreleased (master)
 
+# 0.4.1 (2020-10-05)
+
+## Fixes
+
+* Get public ip of created Droplet
+
 # 0.4.0 (2020-03-20)
 
 ## New features

--- a/lib/onlyoffice_digitalocean_wrapper/digitalocean_wrapper/getters.rb
+++ b/lib/onlyoffice_digitalocean_wrapper/digitalocean_wrapper/getters.rb
@@ -40,7 +40,7 @@ module OnlyofficeDigitaloceanWrapper
         return
       end
       retry_exception do
-        ip = droplet.networks.first.first.ip_address
+        ip = public_ip(droplet)
         OnlyofficeLoggerHelper.log("get_droplet_ip_by_name(#{droplet_name}): #{ip}")
         ip
       end
@@ -59,6 +59,15 @@ module OnlyofficeDigitaloceanWrapper
           status
         end
       end
+    end
+
+    # Get public ip of droplet
+    # @param [DropletKit] droplet to get ip
+    # @return [String] public ip
+    def public_ip(droplet)
+      networks = droplet.networks.to_a.first
+      public_network = networks.find { |net| net.type == 'public'}
+      public_network.ip_address
     end
   end
 end

--- a/lib/onlyoffice_digitalocean_wrapper/version.rb
+++ b/lib/onlyoffice_digitalocean_wrapper/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module OnlyofficeDigitaloceanWrapper
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
   NAME = 'onlyoffice_digitalocean_wrapper'
 end

--- a/spec/droplet_restore_and_operations_spec.rb
+++ b/spec/droplet_restore_and_operations_spec.rb
@@ -25,6 +25,7 @@ describe OnlyofficeDigitaloceanWrapper::DigitalOceanWrapper, retry: 1 do
     it 'restore_image_by_name' do
       digital_ocean.restore_image_by_name(existing_image_name, 'wrapper-test')
       digital_ocean.wait_until_droplet_have_status('wrapper-test')
+      digital_ocean.get_droplet_ip_by_name('wrapper-test')
       digital_ocean.destroy_droplet_by_name('wrapper-test')
       expect(digital_ocean.get_droplet_id_by_name('wrapper-test')).to be_nil
     end

--- a/spec/droplet_restore_and_operations_spec.rb
+++ b/spec/droplet_restore_and_operations_spec.rb
@@ -25,7 +25,6 @@ describe OnlyofficeDigitaloceanWrapper::DigitalOceanWrapper, retry: 1 do
     it 'restore_image_by_name' do
       digital_ocean.restore_image_by_name(existing_image_name, 'wrapper-test')
       digital_ocean.wait_until_droplet_have_status('wrapper-test')
-      digital_ocean.get_droplet_ip_by_name('wrapper-test')
       digital_ocean.destroy_droplet_by_name('wrapper-test')
       expect(digital_ocean.get_droplet_id_by_name('wrapper-test')).to be_nil
     end


### PR DESCRIPTION
Get public ip of created Droplet

Seems like several days ago DO new created Droplets has
VPC enabled by default, making first ip in networks list - private,
like `10.132.0.4`
This changed it and correctly check for public ip, not any IP